### PR TITLE
Update PVP bounds to build with newer LTS

### DIFF
--- a/Dist.cabal
+++ b/Dist.cabal
@@ -24,7 +24,7 @@ library
   exposed-modules:     Numeric.Probability.Distribution
   -- other-modules:
   other-extensions:    BangPatterns, GeneralizedNewtypeDeriving
-  build-depends:       base >=4.7 && <= 4.9.1.0, MonadRandom >=0.3, containers >=0.5
+  build-depends:       base ==4.12.*, MonadRandom ==0.5.*, containers == 0.6.*
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -32,6 +32,6 @@ test-suite Test
   type: exitcode-stdio-1.0
   main-is: Numeric/Probability/Distribution/Test.hs
   other-extensions:    BangPatterns, GeneralizedNewtypeDeriving
-  build-depends:       base >=4.7 && <= 4.9.1.0, MonadRandom >=0.3, containers >=0.5
+  build-depends:       base ==4.12.*, MonadRandom ==0.5.*, containers == 0.6.*
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.5
+resolver: lts-13.11
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
This PR updates the Dist package to compile against a newer stack TLS.

Tested with stack 1.9.3.1 (x86_64), project tests passing.